### PR TITLE
Changed chat prefix to match format suggested by Sanders

### DIFF
--- a/src/main/java/com/atherys/party/chat/PartyChannel.java
+++ b/src/main/java/com/atherys/party/chat/PartyChannel.java
@@ -4,9 +4,7 @@ import com.atherys.chat.model.AtherysChannel;
 import com.atherys.party.AtherysParties;
 import com.atherys.party.entity.Party;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.channel.MessageReceiver;
-import org.spongepowered.api.text.format.TextColors;
 
 import java.util.*;
 
@@ -19,7 +17,7 @@ public class PartyChannel extends AtherysChannel {
         aliases.add("pc");
         this.setAliases(aliases);
         this.setPermission(PERMISSION);
-        this.setPrefix("[&3Party&r]");
+        this.setPrefix("&f[&3P&f]&r");
         this.setSuffix("");
         this.setFormat("%cprefix %player: %message %csuffix");
         this.setName("&3Party");


### PR DESCRIPTION
Changed chat prefix to align with format from sanders:
Party Chat- &f[&3P&f]&f[&6Gennaian Isles&f] &fSanders&3:I want global turned off!